### PR TITLE
Add network sharing

### DIFF
--- a/io.unobserved.furtherance.yml
+++ b/io.unobserved.furtherance.yml
@@ -13,6 +13,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.IdleMonitor
   - --filesystem=xdg-documents
+  - --share=network
 build-options:
   append-path: /usr/lib/sdk/rust-stable/bin
 modules:


### PR DESCRIPTION
The app now requires access to the network to allow it to sync across devices.